### PR TITLE
Using https for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implementation of the Pebble SDK for Cordova.
 
 From your project's root, add the plugin:
 
-```cordova plugin add git@github.com:jbeuckm/cordova-plugin-pebble.git```
+```cordova plugin add https://github.com/jbeuckm/cordova-plugin-pebble.git```
 
 Set the UUID of your companion app, and register callbacks for connect/disconnect events from watches:
 


### PR DESCRIPTION
This is what I get when I use git@, https is easier to use :)

``` sh
Fetching plugin "git@github.com:jbeuckm/cordova-plugin-pebble.git" via plugin registry
Error: 404 Not Found: git
    at RegClient.<anonymous> (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:268:14)
    at Request.self.callback (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/request/index.js:148:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/request/index.js:876:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/request/index.js:827:12)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:929:16
    at process._tickCallback (node.js:419:13)
```
